### PR TITLE
compiler: parse integer literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install roswell
         shell: bash
         run: |
-          curl -L https://raw.githubusercontent.com/roswell/roswell/v21.10.14.111/scripts/install-for-ci.sh | sh -x
+          curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - sbcl-bin
     env:
       LISP: ${{ matrix.lisp }}
+      CI: github
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - sbcl-bin
     env:
       LISP: ${{ matrix.lisp }}
-      CI: github
+      CI_ENV: github
 
     steps:
       - uses: actions/checkout@v2

--- a/DEV.org
+++ b/DEV.org
@@ -1,0 +1,64 @@
+* VM instruction set ideas
+
+- Instructions are represented as byte vectors
+- We use intel style instructions with destination first and operands after
+- We only support numeric operands which are either registers, addresses into the constant table, addresses into the instruction stream, or immediate values
+  - this way we don't have to care about encoding more complicated structures
+  - registers are 16bit unsigned
+  - address of constant table are 16bit unsigned
+  - address into instruction stream are betweend 8 and 64bit unsigned
+  - immediate value are 8 to 64 bit signed
+
+
+** Instruction encoding
+Encode instructions as 8bit unsigned using the two least significant bits to denote the arity.
+This gives us 64 opcodes for each category
+
+Unary Instructions (00):
+
+These instructions have zero or one operand.
+Example unary instruction opcodes: 0x00, 0x04, 0x08, etc.
+Binary Instructions (01):
+
+These instructions have two operands.
+Example binary instruction opcodes: 0x01, 0x05, 0x09, etc.
+Ternary Instructions (11):
+
+These instructions have three operands.
+Example ternary instruction opcodes: 0x03, 0x07, 0x0B, etc.
+
+
+** Introduce an ISA representation which can be used to decode and encode into bytecode
+ The idea here is that it provides a convenient way to describe the isa and have encode / decoder generated automatically
+ #+begin_src common lisp
+(defisa version: 1.0
+ :instruction-set
+ ((0x10 ret () "some documentation")
+  (0x11 loadk ((reg dst) (addr src) "some documentation")
+  (0x12 mov ((reg dst) (reg src)) "some documentation"))))
+
+(setf encode-1.0 (derive-encoder (isa 1.0)))
+(setf decode-1.0 (derive-decoder (isa 1.0)))
+
+(let ((opcode nil)
+       (dst nil)
+       (op1 nil)
+       (op2 ))
+
+ ;; decode-into setfs the provided bindings and this reduces consing and use of values
+ (decode-1.0 (opcode dst op1 op2) instruction-stream
+   (case opcode
+     (%ret ;;do things
+        )
+   ;; dispatch opcode
+   )))
+
+ #+end_src
+
+** Making instructions and execution efficient
+ - The maximum size of an instruction is 152 bits
+ - We decode into existing values using setq, instead of creating new binginds
+ - We do the same for the PC, the ACCU and the FLAGS register
+ - All of this should be cache friendly and well within the 64bit - 128bit cache line size
+
+ - The opcode design should minimize branch misprediction

--- a/README.md
+++ b/README.md
@@ -3,16 +3,20 @@
 # CL-Braces a minimal go compiler and virtual machine
 
 ## State
+
 While I’m making good progress most of this is in very very early development and many of the features only exist in my head. I totally expect this to take maybe a year till this is somewhere in a state I can show it, at the current rate of development. Well I guess that’s just it. If you still feel interested or even want to contribute, please get in contact. I’m happy to nerd out about this :)
 
 ## Goals
+
 Implement a bytecode compiler and virtual machine for a minimal go-like language. Both the compiler and the VM aim to offer sophisticated introspection capabilities, which allow everyone interested in programming language implementations to peek into every state of the compilation & exection process.
 
 In total this aims to be a learning environment for PL implementations (also for myself)
 
 ## Non-Goals
+
 A programming language that is used for real world applications, other than the ones build within this project.
 
 ## Decisions
+
 Use a golike language to show implementations of parsers and compilers for the typical langauge constructs, while still being fairly minimal
 Don’t only implement toy examples but try to give real implementions, that resemble what you would do in a compiler aimed for a real language

--- a/cl-braces.asd
+++ b/cl-braces.asd
@@ -31,8 +31,7 @@
                   :components
                   ((:file "packages")
                    (:file "ast")
-                   (:file "parser")))
-                 ))))
+                   (:file "parser")))))))
 
 (defsystem "cl-braces/compiler/tests"
   :depends-on (:clunit2 :cl-braces/compiler)

--- a/cl-braces.asd
+++ b/cl-braces.asd
@@ -13,12 +13,18 @@
 
 (defsystem "cl-braces/compiler"
   :description "Compiler for cl-braces the minimal go-like programming language"
-  :depends-on (:alexandria
-               :serapeum)
+  :depends-on (:alexandria :serapeum)
   :in-order-to ((test-op (test-op "cl-braces/compiler/tests")))
   :serial t
   :pathname "src/compiler"
-  :components ((:file "packages")))
+  :components ((:module "frontend"
+                :components
+                ((:module "scanner"
+                  :components
+                  ((:file "packages")
+                   (:file "input")
+                   (:file "token")
+                   (:file "scanner")))))))
 
 (defsystem "cl-braces/compiler/tests"
   :depends-on (:clunit2 :cl-braces/compiler)
@@ -26,7 +32,10 @@
   :pathname "tests/compiler"
   :components
   ((:file "packages")
-   (:file "suites"))
+   (:file "suites")
+   (:module "frontend"
+    :components
+    ((:file "scanner_suite"))))
   :perform (test-op (o c)
                     (declare (ignore o c))
-                    (uiop:symbol-call :cl-braces.compiler.tests :run-all-with-exit)))
+                    (uiop:symbol-call :cl-braces.compiler.tests :run-all)))

--- a/cl-braces.asd
+++ b/cl-braces.asd
@@ -17,14 +17,22 @@
   :in-order-to ((test-op (test-op "cl-braces/compiler/tests")))
   :serial t
   :pathname "src/compiler"
-  :components ((:module "frontend"
+  :components ((:file "../development")
+               (:module "frontend"
                 :components
                 ((:module "scanner"
                   :components
                   ((:file "packages")
                    (:file "input")
                    (:file "token")
-                   (:file "scanner")))))))
+                   (:file "scanner")))
+
+                 (:module "parser"
+                  :components
+                  ((:file "packages")
+                   (:file "ast")
+                   (:file "parser")))
+                 ))))
 
 (defsystem "cl-braces/compiler/tests"
   :depends-on (:clunit2 :cl-braces/compiler)
@@ -35,7 +43,8 @@
    (:file "suites")
    (:module "frontend"
     :components
-    ((:file "scanner_suite"))))
+    ((:file "scanner_suite")
+     (:file "parser_suite"))))
   :perform (test-op (o c)
                     (declare (ignore o c))
                     (uiop:symbol-call :cl-braces.compiler.tests :run-all)))

--- a/src/compiler/frontend/parser/ast.lisp
+++ b/src/compiler/frontend/parser/ast.lisp
@@ -1,0 +1,30 @@
+(in-package :cl-braces.compiler.frontend.ast)
+
+(defclass node ()
+  ((location :reader location
+             :initarg :location
+             :initform (error "must provide location")
+             :type token:location
+             :documentation "The location of the start of the node in the source code."))
+  (:documentation "The base class for all AST nodes in the highlevel AST."))
+
+(defclass expression (node) ()
+  (:documentation "The base class for all expressions in the highlevel AST."))
+
+(defclass bad-expression (expression)
+  ((message :reader bad-expression-message
+            :initarg :message
+            :initform (error "must provide message")
+            :type string))
+  (:documentation "An expression that could not be parsed correctly."))
+
+(defclass literal (expression)
+  ((token :reader literal-token
+          :initarg :token
+          :initform (error "must provide token")
+          :type token:token))
+  (:documentation "The base class for all literals in the highlevel AST."))
+
+(-> literal-value (literal) t)
+(defun literal-value (expression)
+  (token:value (literal-token expression)))

--- a/src/compiler/frontend/parser/packages.lisp
+++ b/src/compiler/frontend/parser/packages.lisp
@@ -1,0 +1,23 @@
+(in-package :cl-user)
+
+(defpackage :cl-braces.compiler.frontend.ast
+  (:nicknames :frontend.ast :ast)
+  (:use :cl)
+  (:import-from :serapeum :->)
+  (:export
+   :node
+   :expression
+   :bad-expression
+   :literal
+   :literal-value
+
+   :walk
+   :enter
+   :leave))
+
+(defpackage :cl-braces.compiler.frontend.parser
+  (:nicknames :frontend.parser :parser)
+  (:use :cl)
+  (:import-from :serapeum :->)
+  (:export
+   :parse))

--- a/src/compiler/frontend/parser/parser.lisp
+++ b/src/compiler/frontend/parser/parser.lisp
@@ -1,5 +1,10 @@
 (in-package :cl-braces.compiler.frontend.parser)
 
+;;; This implements the parser for the highlevel language.
+;;; It's a hand rolled recursive descent parser, which collects parse errors and reports them collectively at the end of the parsing process.
+;;; When a parse fails, the parse will insert a sentinel node into the AST and continue parsing.
+;;; The recovery is relatively simple and attempts to synchronize to the next statement boundary.
+
 (defparameter *fail-fast* nil "If true the parser will signal a continuable parse-error condition when an error is encountered. When continued the parser will attempt to synchronize to the next statement boundary.")
 
 (define-condition parse-errors (error)

--- a/src/compiler/frontend/parser/parser.lisp
+++ b/src/compiler/frontend/parser/parser.lisp
@@ -53,9 +53,11 @@
   (:documentation "The state of the parser which is threaded through all parsing methods"))
 
 (defun parse (input-desginator)
-  (scanner:with-scanner (scanner input-desginator)
-    (let ((state (make-instance 'state :scanner scanner)))
-      (%parse state))))
+  (scanner:call-with-scanner
+   input-desginator
+   (lambda (scanner)
+     (let ((state (make-instance 'state :scanner scanner)))
+       (%parse state)))))
 
 (-> %parse (state) ast:node)
 (defun %parse (state)

--- a/src/compiler/frontend/parser/parser.lisp
+++ b/src/compiler/frontend/parser/parser.lisp
@@ -1,0 +1,129 @@
+(in-package :cl-braces.compiler.frontend.parser)
+
+(defparameter *fail-fast* nil "If true the parser will signal a continuable parse-error condition when an error is encountered. When continued the parser will attempt to synchronize to the next statement boundary.")
+
+(define-condition parse-errors (error)
+  ((details :reader error-detail
+            :initarg :details))
+  (:documentation "The parser will collect parser errors and once the parsing process is finished it will signal this error condition containing all the details"))
+
+(define-condition error-detail (error)
+  ((location :reader error-location
+             :initarg :location
+             :type token:location)
+   (message :reader error-message
+            :initarg :message))
+  (:report
+   (lambda (condition stream)
+     (let ((location (error-location condition)))
+       (format stream "ParseError at Line: ~A, Column: ~A => ~A" (token:location-line location) (token:location-column location) (error-message condition)))))
+  (:documentation "An instance of a parse error."))
+
+(defclass state ()
+  ((scanner
+    :initarg :scanner
+    :initform (error "must provide scanner")
+    :type scanner:state
+    :documentation "The scanner to read tokens from")
+   (cur-token
+    :initarg :cur-token
+    :initform nil
+    :type (or null token:token)
+    :documentation "The most recently read token")
+   (next-token
+    :initarg :next-token
+    :initform nil
+    :type (or null token:token)
+    :documentation "The next token to be read")
+   (errors
+    :initarg :errors
+    :initform nil
+    :type list
+    :documentation "A list of parse errors that have been encountered")
+   (had-errors-p
+    :initarg :had-errors-p
+    :initform nil
+    :type boolean
+    :documentation "A flag indicating if any errors have been encountered")
+   (panic-mode-p
+    :initarg :panic-mode-p
+    :initform nil
+    :type boolean
+    :documentation "A flag indicating if the parser is in panic mode"))
+  (:documentation "The state of the parser which is threaded through all parsing methods"))
+
+(defun parse (input-desginator)
+  (scanner:with-scanner (scanner input-desginator)
+    (let ((state (make-instance 'state :scanner scanner)))
+      (%parse state))))
+
+(-> %parse (state) ast:node)
+(defun %parse (state)
+  (handler-bind ((error-detail (lambda (c) (if *fail-fast* (invoke-debugger c) (invoke-restart 'continue)))))
+    (advance! state)
+    (when (eofp state)
+      (error-at-current state "Unexpected end of input")
+      (return-from %parse (accept state 'ast:bad-expression)))
+    (parse-number-literal state)))
+
+(-> parse-number-literal (state) (or null ast:expression))
+(defun parse-number-literal (state)
+  (let ((tok (consume! state token:@INTEGER "Expected number literal")))
+    (unless (token:class= tok token:@ILLEGAL)
+      (accept state 'ast:literal :token tok))))
+
+(-> eofp (state) boolean)
+(defun eofp (state)
+  (with-slots (cur-token) state
+    (token:class= cur-token token:@EOF)))
+
+(-> accept (state symbol &rest t) (values ast:node &optional))
+(defun accept (state node-class &rest args)
+  (with-slots (cur-token) state
+    (if cur-token
+        (apply #'make-instance node-class :location (token:location cur-token) args)
+        (dev:unreachable! "No current token"))))
+
+(-> advance! (state) (values token:token token:token))
+(defun advance! (state)
+  (with-slots (next-token cur-token scanner) state
+    (let ((cur (scanner:next-token scanner)))
+      (if (and cur-token next-token)
+          (rotatef cur-token next-token cur)
+          (progn
+            (setf cur-token cur)
+            (setf next-token (scanner:next-token scanner))))
+      (when (token:class= cur-token token:@ILLEGAL)
+        (error-at-current parser "Illegal token"))
+      (values cur-token next-token))))
+
+(-> consume! (state token:token-class string &rest list) token:token)
+(defun consume! (state expected-token-class format-string &rest args)
+  "Consumes input expecting it to be of the given token type"
+  (with-slots (cur-token) state
+    (assert cur-token) ; we can only get here when consume! has been called withoud advance!
+
+    (unless (token:class= cur-token expected-token-class)
+      (error-at-current state format-string args))
+    (prog1 cur-token
+      (advance! state))))
+
+(-> error-at-current (state string &rest t) null)
+(defun error-at-current (state format-string &rest args)
+  "Record an error at the current location"
+  (with-slots (cur-token) state
+    (apply #'error-at state cur-token format-string args)))
+
+(-> error-at (state token:token string &rest t) null)
+(defun error-at (state token format-string &rest args)
+  (with-slots (panic-mode-p had-errors-p errors scanner) state
+
+    (when panic-mode-p (return-from error-at))
+
+    (setf panic-mode-p t)
+    (setf had-error-p t)
+
+    (let* ((loc (token:location token))
+           (parse-error (make-condition 'error-detail :location loc :message (apply #'format nil format-string args))))
+      (cerror "Continue parsing collecting this error" parse-error)
+      (push parse-error errors))))

--- a/src/compiler/frontend/scanner/input.lisp
+++ b/src/compiler/frontend/scanner/input.lisp
@@ -42,7 +42,7 @@
          (uri (format nil "string://~a" label)))
     (call-next-method input :uri uri :label label :string string :stream (make-string-input-stream string))))
 
-(defgeneric open-input (input-desginator &rest args)
+(defgeneric open-input (input-desginator)
   (:documentation
    "Opens an input stream for the given input designator.
 The call-site has to make sure that the input is properly closed again.
@@ -51,21 +51,19 @@ For most use-cases you should use `call-with-input' or `with-input' respectively
 (defgeneric close-input (source-input)
   (:documentation  "Closes the given input stream."))
 
-(defmethod open-input ((inp source-input) &rest args) ; specialization for when we already have ac constructed input
-  (declare (ignore args))
+(defmethod open-input ((inp source-input)) ; specialization for when we already have ac constructed input
   inp)
 
-(defmethod open-input ((input-designator string) &rest args)
-  (let ((label (getf args :label)))
-    (make-instance 'string-input :string input-designator :label label)))
+(defmethod open-input ((input-designator string))
+  (make-instance 'string-input :string input-designator))
 
 (defmethod close-input ((input string-input)) nil)
 
-(defun call-with-input (input-designator fn &rest open-args)
+(defun call-with-input (input-designator fn)
   "Constructs a `source-input' from the given input designator and calls the provided `function' with that input.
 The `input' is closed automatically after the `function' has been called."
 
-  (let ((input (apply #'open-input input-designator open-args)))
+  (let ((input (open-input input-designator)))
     (unwind-protect
          (funcall fn input)
       (close-input input))))

--- a/src/compiler/frontend/scanner/input.lisp
+++ b/src/compiler/frontend/scanner/input.lisp
@@ -1,0 +1,60 @@
+(in-package :cl-braces.compiler.frontend.scanner)
+
+(defclass source-location ()
+  ((line :reader location-line :initarg :line :initform (error "no line given") :type (integer 1 *) :documentation "The line in the input stream, 1 based.")
+   (column :reader location-column :initarg :column :initform (error "no column given") :type (integer 1 *) :documentation "The column in the input stream, 1 based.")
+   (offset :reader location-offset :initarg :offset :initform (error "no offset given") :type (integer 0 *) :documentation "The offset in the input stream, 0 based."))
+  (:documentation "A source location is a position in the input stream. It is used to denote the position of a token in the input stream"))
+
+(defmethod print-object ((location source-location) stream)
+  (with-slots (line column offset) location
+    (print-unreadable-object (location stream :type t :identity t)
+      (format stream "line: ~a column: ~a offset: ~a" line column offset))))
+
+(defclass source-input ()
+  ((uri :reader source-input-uri :initarg :uri :initform (error "no uri given") :type string :documentation "The uri of the input stream. This is used to identify the input stream.")
+   (stream :reader source-input-stream :initarg :stream :initform (error "no stream given") :type stream :documentation "The input stream itself. This is used to read the input stream."))
+  (:documentation "A source input is a stream of characters. It is used to read the input stream."))
+
+(defmethod print-object ((input source-input) stream)
+  (with-slots (uri) input
+    (print-unreadable-object (input stream :type t :identity t)
+      (format stream "uri: ~a" uri))))
+
+(defclass string-input (source-input)
+  ((label :reader :string-input-label :initarg :label :initform "anonymous" :type string :documentation "The label of the string input. This is used to identify the string input.")
+   (string :reader :string-input-string :initarg :string :initform (error "no string given") :type string :documentation "The string that is being read."))
+  (:documentation "A string input is a source input that reads from a string."))
+
+(defmethod print-object ((input string-input) stream)
+  (with-slots (label string) input
+    (print-unreadable-object (input stream :type t :identity t)
+      (format stream "label: ~a string: ~a" label string))))
+
+(defmethod initialize-instance :around ((input string-input) &rest initargs &key &allow-other-keys)
+  (let* ((string (getf initargs :string))
+         (label (getf initargs :label))
+         (uri (format nil "string://~a" label)))
+    (call-next-method input :uri uri :label label :string string :stream (make-string-input-stream string))))
+
+(defgeneric open-input (input-desginator &rest args))
+
+(defgeneric close-input (source-input))
+
+(defmethod open-input ((input-designator string) &rest args)
+  (let ((label (getf args :label)))
+    (make-instance 'string-input :string input-designator :label label)))
+
+(defmethod close-input ((input string-input))
+  nil)
+
+(defun call-with-input (input-designator function &rest open-args)
+  "Calls the given function with the input stream of the input designator. The input designator can be either a string"
+  (let ((input (apply #'open-input input-designator open-args)))
+    (unwind-protect
+         (funcall function input)
+      (close-input input))))
+
+(defmacro with-input ((input-var input-designator &rest args &key &allow-other-keys) &body body)
+  "Calls the given body with the input stream of the input designator."
+  `(apply #'call-with-input ,input-designator (lambda (,input-var) ,@body) ,@args))

--- a/src/compiler/frontend/scanner/input.lisp
+++ b/src/compiler/frontend/scanner/input.lisp
@@ -51,6 +51,10 @@ For most use-cases you should use `call-with-input' or `with-input' respectively
 (defgeneric close-input (source-input)
   (:documentation  "Closes the given input stream."))
 
+(defmethod open-input ((inp source-input) &rest args) ; specialization for when we already have ac constructed input
+  (declare (ignore args))
+  inp)
+
 (defmethod open-input ((input-designator string) &rest args)
   (let ((label (getf args :label)))
     (make-instance 'string-input :string input-designator :label label)))
@@ -65,9 +69,3 @@ The `input' is closed automatically after the `function' has been called."
     (unwind-protect
          (funcall fn input)
       (close-input input))))
-
-(defmacro with-input ((input-var input-designator &rest args) &body body)
-  "Constructs a `source-input' from the given input designator and binds it to `input-var' for the duration of `body'.
-It closes the `input' automatically after `body' has been executed.
-"
-  `(call-with-input ,input-designator (lambda (,input-var) ,@body) ,@args))

--- a/src/compiler/frontend/scanner/input.lisp
+++ b/src/compiler/frontend/scanner/input.lisp
@@ -57,16 +57,17 @@ For most use-cases you should use `call-with-input' or `with-input' respectively
 
 (defmethod close-input ((input string-input)) nil)
 
-(defun call-with-input (input-designator function &rest open-args)
+(defun call-with-input (input-designator fn &rest open-args)
   "Constructs a `source-input' from the given input designator and calls the provided `function' with that input.
 The `input' is closed automatically after the `function' has been called."
+
   (let ((input (apply #'open-input input-designator open-args)))
     (unwind-protect
-         (funcall function input)
+         (funcall fn input)
       (close-input input))))
 
-(defmacro with-input ((input-var input-designator &rest args &key &allow-other-keys) &body body)
+(defmacro with-input ((input-var input-designator &rest args) &body body)
   "Constructs a `source-input' from the given input designator and binds it to `input-var' for the duration of `body'.
 It closes the `input' automatically after `body' has been executed.
 "
-  `(apply #'call-with-input ,input-designator (lambda (,input-var) ,@body) ,@args))
+  `(call-with-input ,input-designator (lambda (,input-var) ,@body) ,@args))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -1,5 +1,22 @@
 (in-package :cl-user)
 
+(defpackage :cl-braces.compiler.frontend.token
+  (:nicknames :frontend.token :token)
+  (:use :cl)
+  (:import-from :serapeum :->)
+  (:export
+   :token
+   :token-class
+   :token-lexeme
+   :token-value
+
+   :token-class
+   :class=
+
+   :@EOF
+   :@ILLEGAL
+   :@INTEGER))
+
 (defpackage :cl-braces.compiler.frontend.scanner
   (:nicknames :frontend.scanner :scanner)
   (:use :cl)
@@ -7,15 +24,4 @@
   (:export
    :call-with-scanner
    :with-scanner
-   :next-token
-
-   :token
-   :token-type
-   :token-value
-   :token-text
-
-   :tpe-token-type
-   :tok-eof
-   :tok-illegal
-   :tok-integer
-   ))
+   :next-token))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -26,7 +26,7 @@
 (defpackage :cl-braces.compiler.frontend.scanner
   (:nicknames :frontend.scanner :scanner)
   (:use :cl)
-  (:import-from :serapeum :-> :defunion :defunit)
+  (:import-from :serapeum :->)
   (:export
    :call-with-scanner
    :with-scanner

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -1,0 +1,19 @@
+(in-package :cl-user)
+
+(defpackage :cl-braces.compiler.frontend.scanner
+  (:nicknames :frontend.scanner :scanner)
+  (:use :cl)
+  (:import-from :serapeum :->)
+  (:export
+   :call-with-scanner
+   :with-scanner
+   :next-token
+
+   :token
+   :token-type
+   :token-value
+   :token-text
+
+   :tpe-token-type
+   :tok-eof
+   :tok-illegal))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -13,6 +13,8 @@
    :token-class
    :class=
 
+   :location
+
    :@EOF
    :@ILLEGAL
    :@INTEGER))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -6,18 +6,20 @@
   (:import-from :serapeum :->)
   (:export
    :token
-   :token-class
-   :token-lexeme
-   :token-value
-
-   :token-class
-   :class=
-
+   :class
+   :lexeme
+   :value
    :location
+
+   :class=
+   :token-class-t
+
+   :source-location
 
    :@EOF
    :@ILLEGAL
-   :@INTEGER))
+   :@INTEGER)
+  (:shadow :class))
 
 (defpackage :cl-braces.compiler.frontend.scanner
   (:nicknames :frontend.scanner :scanner)

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -10,13 +10,13 @@
    :lexeme
    :value
    :location
-   :location-line
-   :location-column
-
-   :class=
    :token-class
+   :class=
 
    :source-location
+   :location-offset
+   :location-line
+   :location-column
 
    :@EOF
    :@ILLEGAL
@@ -28,8 +28,9 @@
   (:use :cl)
   (:import-from :serapeum :->)
   (:export
+   :open-scanner
+   :close-scanner
    :call-with-scanner
-   :with-scanner
    :with-input
    :next-token
    :state))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -16,4 +16,6 @@
 
    :tpe-token-type
    :tok-eof
-   :tok-illegal))
+   :tok-illegal
+   :tok-integer
+   ))

--- a/src/compiler/frontend/scanner/packages.lisp
+++ b/src/compiler/frontend/scanner/packages.lisp
@@ -10,9 +10,11 @@
    :lexeme
    :value
    :location
+   :location-line
+   :location-column
 
    :class=
-   :token-class-t
+   :token-class
 
    :source-location
 
@@ -24,8 +26,10 @@
 (defpackage :cl-braces.compiler.frontend.scanner
   (:nicknames :frontend.scanner :scanner)
   (:use :cl)
-  (:import-from :serapeum :->)
+  (:import-from :serapeum :-> :defunion :defunit)
   (:export
    :call-with-scanner
    :with-scanner
-   :next-token))
+   :with-input
+   :next-token
+   :state))

--- a/src/compiler/frontend/scanner/scanner.lisp
+++ b/src/compiler/frontend/scanner/scanner.lisp
@@ -101,10 +101,6 @@ It uses `call-with-input' which inturn ensures that.
   "Opens a new scanner that is initialized with the input stream of the input designator."
   (make-instance 'state :input (open-input input-designator args)))
 
-(defmacro with-scanner ((state-var input-designator &rest args) &body body)
-  "Calls the given body with a new scanner that is initialized with the input stream of the input designator."
-  `(call-with-scanner ,input-designator (lambda (,state-var) ,@body) ,@args))
-
 (-> next-token (state) token:token)
 (defun next-token (state)
   "Reads the next available token from the input stream. Unless something catastrophic happens this function will always

--- a/src/compiler/frontend/scanner/scanner.lisp
+++ b/src/compiler/frontend/scanner/scanner.lisp
@@ -183,7 +183,7 @@ return a token. There are special kinds of tokens that denote `illegal input' as
   (when (funcall predicate (peek state))
     (advance! state)))
 
-(-> accept (state token:token-class &optional function) token:token)
+(-> accept (state token:token-class-t &optional function) token:token)
 (defun accept (scanner token-class &optional (to-value #'identity))
   "Accept the scanned lexeme and constructs a `token:token' from it using the provided `token-class'.
 If `to-value' is provided it must be a function of one argument that will be applied to the lexeme to produce the value of the token.
@@ -191,7 +191,7 @@ If `token-class' is :@ILLEGAL then a `scan-error' condition is signalled."
   (with-slots (lexeme token-offset token-column token-line) scanner
     (let* ((token-lexeme (coerce lexeme 'string))
            (value (funcall to-value token-lexeme))
-           (location (make-instance 'token:location :line token-line :column token-column :offset token-offset)))
+           (location (make-instance 'token:source-location :line token-line :column token-column :offset token-offset)))
       (let ((token (make-instance 'token:token :class token-class :lexeme lexeme :value value :location location)))
         (prog1 token
           (when (token:class= token :@ILLEGAL)

--- a/src/compiler/frontend/scanner/scanner.lisp
+++ b/src/compiler/frontend/scanner/scanner.lisp
@@ -1,6 +1,5 @@
 (in-package :cl-braces.compiler.frontend.scanner)
 
-;;;;
 ;;;; The scanner is the first stage of the compiler. It takes a stream of characters and produces a stream of tokens.
 ;;;; A token is a representation of a lexeme in the input stream bundled with some metadata about the location and the class of the lexeme.
 ;;;; The token's class is used by the parser to determine how to interpret the token.

--- a/src/compiler/frontend/scanner/scanner.lisp
+++ b/src/compiler/frontend/scanner/scanner.lisp
@@ -1,0 +1,137 @@
+(in-package :cl-braces.compiler.frontend.scanner)
+
+(deftype tpe-token-type ()
+  "The type of a token. This is a simple enumeration of all the different kinds of tokens that can be encountered in the"
+  '(member
+    :tok-illegal
+    :tok-eof))
+
+(defclass token ()
+  ((type :reader token-type :initarg :type :initform (error "no type given") :type tpe-token-type)
+   (text :reader token-text :initarg :text :initform (error "no text given") :type string)
+   (value :reader token-value :initarg :value :initform nil :type (or null t))
+   (location :reader token-location :initarg :location :initform (error "no location given") :type source-location))
+  (:documentation "A token is a single unit of input. It is the smallest unit of input that the parser can work with."))
+
+(defmethod print-object ((token token) stream)
+  (with-slots (type text value location) token
+    (print-unreadable-object (token stream :type t :identity t)
+      (format stream "type: ~a text: ~a value: ~a location: ~a" type text value location))))
+
+(defparameter *fail-fast* nil "If true, the scanner will enter the debugger when an error is encountered")
+
+(define-condition scan-error (error)
+  ((message :initarg :message :reader scan-error-message)
+   (location :initarg :location :reader scan-error-location))
+  (:report (lambda (condition stream)
+             (format stream "Illegal token at ~a" (scan-error-location condition)))))
+
+(defclass state ()
+  ((input :reader state-input :initarg :input :initform (error "no input given") :type source-input :documentation "The input that is being scanned. Must be a character stream.")
+   (input-stream :initform nil :type (or null stream) :documentation "The input stream that is being scanned. Must be a character stream.")
+
+   (consumed :initform (make-array 0 :element-type 'character :adjustable t :fill-pointer 0) :type (vector character) :documentation "The characters that have been consumed so far")
+   (token-offset  :initarg :start :initform 0 :type integer :documentation "The start position of the current token")
+   (token-column :initarg :column :initform 1 :type integer :documentation "The column in the input stream, where the current token starts")
+   (token-line  :initarg :line :initform 1 :type integer :documentation "The line in the input stream, where the current token starts")
+
+   (stream-line  :initarg :line :initform 1 :type integer :documentation "The line in the input stream, where the current token starts")
+   (stream-column :initarg :column :initform 1 :type integer :documentation "The column in the input stream, where the current token starts")
+   (stream-offset :initarg :offset :initform 0 :type integer :documentation "The offset in the input stream, where the current token starts"))
+  (:documentation "The state of the scanner. This is the object that is passed around to all the different functions that scan the input"))
+
+(defmethod print-object ((state state) stream)
+  (with-slots (input consumed token-offset stream-line stream-column stream-offset) state
+    (print-unreadable-object (state stream :type t :identity t)
+      (format stream "input: ~a consumed: ~a start: ~a line: ~a column: ~a offset: ~a" input consumed token-offset stream-line stream-column stream-offset))))
+
+(defmethod initialize-instance :after ((state state) &key)
+  (with-slots (input-stream input) state
+    (setf input-stream (source-input-stream input))))
+
+(defun call-with-scanner (input-designator function &rest args)
+  "Calls the given function with a new scanner that is initialized with the input stream of the input designator."
+  (call-with-input input-designator
+                   (lambda (input)
+                     (let ((state (make-instance 'state :input input)))
+                       (apply function state args)))))
+
+(defun open-scanner (input-designator &rest args)
+  "Opens a new scanner that is initialized with the input stream of the input designator."
+  (make-instance 'state :input (open-input input-designator args)))
+
+(defmacro with-scanner ((state-var input-designator &rest args) &body body)
+  "Calls the given body with a new scanner that is initialized with the input stream of the input designator."
+  `(apply #'call-with-scanner
+    ,input-designator (lambda (,state-var) ,@body)
+    ,@args))
+
+(-> next-token (state) token)
+(defun next-token (state)
+  "Reads the next available token from the input stream. Unless something catastrophic happens this function will always
+return a token. There are special kinds of tokens that denote `illegal input' as well as `end of input'"
+  (handler-bind ((scan-error (lambda (e)
+                               (if *fail-fast*
+                                   (invoke-debugger e)
+                                   (when (find-restart 'continue)
+                                     (invoke-restart 'continue))))))
+    (%next-token state)))
+
+(-> %next-token (state) token)
+(defun %next-token (state)
+  (with-slots (token-offset token-column token-line stream-offset stream-column stream-line) state
+    (setf token-offset stream-offset)
+    (setf token-column stream-column)
+    (setf token-line stream-line)
+    (or
+     (scan-eof state)
+     (scan-illegal state))))
+
+(-> scan-eof (state) (or null token))
+(defun scan-eof (state)
+  (when (eofp state)
+    (accept state :tok-eof)))
+
+(-> scan-illegal (state)  token)
+(defun scan-illegal (state)
+  (advance! state)
+  (accept state :tok-illegal))
+
+(-> eofp (state) boolean)
+(defun eofp (state)
+  "Returns true if the scanner has reached the end of the input stream."
+  (null (peek state)))
+
+(-> peek (state) (or null character))
+(defun peek (state)
+  "Peeks at the next character in the input stream without advancing the scanner."
+  (with-slots (input-stream) state
+    (peek-char nil input-stream nil nil)))
+
+(-> advance! (state) (or null character))
+(defun advance! (scanner)
+  "Advance the scanner to the next character, adjusting internal state to keep track of location in the input stream.
+   Returns the character that was advanced to or nil if the end of the input has been reached."
+  (with-slots (input-stream stream-line stream-offset stream-column consumed) scanner
+    (let ((current-char (read-char input-stream nil)))
+      (when current-char
+        (incf stream-column)
+        (incf stream-offset)
+        (vector-push-extend current-char consumed)
+        (when (eql current-char #\Newline)
+          (incf stream-line)
+          (setf stream-column 0))
+        current-char))))
+
+(-> accept (state tpe-token-type &key (to-value t)) token)
+(defun accept (scanner token-type &key (to-value #'identity))
+  "Accept the next token and return it. It the token is illegal the scate will signal a contiuabl scan-error."
+  (with-slots (consumed token-offset token-column token-line) scanner
+    (let* ((token-text (coerce consumed 'string))
+           (value (funcall to-value token-text))
+           (location (make-instance 'source-location :line token-line :column token-column :offset token-offset)))
+      (setf consumed (make-array 0 :element-type 'character :adjustable t :fill-pointer 0))
+      (let ((token (make-instance 'token :type token-type :text token-text :value value :location location)))
+        (prog1 token
+          (when (eql token-type :tok-illegal)
+            (cerror "Illegal token" (make-condition 'scan-error :message "Illegal token" :location location))))))))

--- a/src/compiler/frontend/scanner/scanner.lisp
+++ b/src/compiler/frontend/scanner/scanner.lisp
@@ -191,8 +191,8 @@ If `token-class' is :@ILLEGAL then a `scan-error' condition is signalled."
   (with-slots (lexeme token-offset token-column token-line) scanner
     (let* ((token-lexeme (coerce lexeme 'string))
            (value (funcall to-value token-lexeme))
-           (location (make-instance 'source-location :line token-line :column token-column :offset token-offset)))
-      (let ((token (make-instance 'token :class token-class :lexeme lexeme :value value :location location)))
+           (location (make-instance 'token:location :line token-line :column token-column :offset token-offset)))
+      (let ((token (make-instance 'token:token :class token-class :lexeme lexeme :value value :location location)))
         (prog1 token
           (when (token:class= token :@ILLEGAL)
             (cerror "Illegal token" (make-condition 'scan-error :message "Illegal token" :location location))))))))

--- a/src/compiler/frontend/scanner/token.lisp
+++ b/src/compiler/frontend/scanner/token.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-braces.compiler.frontend.token)
 
-(defclass location ()
+(defclass source-location ()
   ((line :reader location-line
          :initarg :line
          :initform (error "no line given")
@@ -18,12 +18,12 @@
            :documentation "The offset in the input stream, 0 based."))
   (:documentation "A source location is a position in the input stream. It is used to denote the position of a token in the input stream"))
 
-(defmethod print-object ((location location) stream)
+(defmethod print-object ((location source-location) stream)
   (with-slots (line column offset) location
     (print-unreadable-object (location stream :type t :identity t)
       (format stream "line: ~a column: ~a offset: ~a" line column offset))))
 
-(deftype token-class ()
+(deftype token-class-t ()
   "The token's ^class is union type of all possible token classes."
   '(member
     :@ILLEGAL
@@ -31,22 +31,22 @@
     :@INTEGER))
 
 (defclass token ()
-  ((class :reader token-class
+  ((class :reader class
           :initarg :class
           :initform (error "no type given")
-          :type token-class)
-   (lexeme :reader token-lexeme
+          :type token-class-t)
+   (lexeme :reader lexeme
            :initarg :lexeme
            :initform (error "no lexeme given")
            :type string)
-   (value :reader token-value
+   (value :reader value
           :initarg :value
           :initform nil
           :type (or null t))
-   (location :reader token-location
+   (location :reader location
              :initarg :location
              :initform (error "no location given")
-             :type location))
+             :type source-location))
   (:documentation "A token is a single unit of input. It is the smallest unit of input that the parser can work with."))
 
 (defmethod print-object ((token token) stream)
@@ -54,7 +54,8 @@
     (print-unreadable-object (token stream :type t :identity t)
       (format stream "type: ~a lexeme: ~a value: ~a location: ~a" type lexeme value location))))
 
-(-> class= (token token-class) boolean)
+(-> class= (token token-class-t) boolean)
 (defun class= (token expected-class)
   "Returns true if the token's class is equal to the given `expected-class.'"
-  (eql (token-class token) expected-class))
+  (with-slots (class) token
+    (eql class expected-class)))

--- a/src/compiler/frontend/scanner/token.lisp
+++ b/src/compiler/frontend/scanner/token.lisp
@@ -23,18 +23,16 @@
     (print-unreadable-object (location stream :type t :identity t)
       (format stream "line: ~a column: ~a offset: ~a" line column offset))))
 
-(deftype token-class-t ()
-  "The token's ^class is union type of all possible token classes."
-  '(member
-    :@ILLEGAL
-    :@EOF
-    :@INTEGER))
+(serapeum:defunion token-class
+  @ILLEGAL
+  @EOF
+  @INTEGER)
 
 (defclass token ()
   ((class :reader class
           :initarg :class
           :initform (error "no type given")
-          :type token-class-t)
+          :type token-class)
    (lexeme :reader lexeme
            :initarg :lexeme
            :initform (error "no lexeme given")
@@ -50,11 +48,11 @@
   (:documentation "A token is a single unit of input. It is the smallest unit of input that the parser can work with."))
 
 (defmethod print-object ((token token) stream)
-  (with-slots (type lexeme value location) token
+  (with-slots (class lexeme value location) token
     (print-unreadable-object (token stream :type t :identity t)
-      (format stream "type: ~a lexeme: ~a value: ~a location: ~a" type lexeme value location))))
+      (format stream "class: ~a lexeme: ~a value: ~a location: ~a" class lexeme value location))))
 
-(-> class= (token token-class-t) boolean)
+(-> class= (token token-class) boolean)
 (defun class= (token expected-class)
   "Returns true if the token's class is equal to the given `expected-class.'"
   (with-slots (class) token

--- a/src/compiler/frontend/scanner/token.lisp
+++ b/src/compiler/frontend/scanner/token.lisp
@@ -1,19 +1,60 @@
-(in-package :cl-braces.compiler.frontend.scanner)
+(in-package :cl-braces.compiler.frontend.token)
 
-(deftype tpe-token-type ()
-  "The type of a token. This is a simple enumeration of all the different kinds of tokens that can be encountered in the"
+(defclass location ()
+  ((line :reader location-line
+         :initarg :line
+         :initform (error "no line given")
+         :type (integer 1 *)
+         :documentation "The line in the input stream, 1 based.")
+   (column :reader location-column
+           :initarg :column
+           :initform (error "no column given")
+           :type (integer 1 *)
+           :documentation "The column in the input stream, 1 based.")
+   (offset :reader location-offset
+           :initarg :offset
+           :initform (error "no offset given")
+           :type (integer 0 *)
+           :documentation "The offset in the input stream, 0 based."))
+  (:documentation "A source location is a position in the input stream. It is used to denote the position of a token in the input stream"))
+
+(defmethod print-object ((location location) stream)
+  (with-slots (line column offset) location
+    (print-unreadable-object (location stream :type t :identity t)
+      (format stream "line: ~a column: ~a offset: ~a" line column offset))))
+
+(deftype token-class ()
+  "The token's ^class is union type of all possible token classes."
   '(member
-    :tok-illegal
-    :tok-eof))
+    :@ILLEGAL
+    :@EOF
+    :@INTEGER))
 
 (defclass token ()
-  ((type :reader token-type :initarg :type :initform (error "no type given") :type tpe-token-type)
-   (text :reader token-text :initarg :text :initform (error "no text given") :type string)
-   (value :reader token-value :initarg :value :initform nil :type (or null t))
-   (location :reader token-location :initarg :location :initform (error "no location given") :type source-location))
+  ((class :reader token-class
+          :initarg :class
+          :initform (error "no type given")
+          :type token-class)
+   (lexeme :reader token-lexeme
+           :initarg :lexeme
+           :initform (error "no lexeme given")
+           :type string)
+   (value :reader token-value
+          :initarg :value
+          :initform nil
+          :type (or null t))
+   (location :reader token-location
+             :initarg :location
+             :initform (error "no location given")
+             :type location))
   (:documentation "A token is a single unit of input. It is the smallest unit of input that the parser can work with."))
 
 (defmethod print-object ((token token) stream)
-  (with-slots (type text value location) token
+  (with-slots (type lexeme value location) token
     (print-unreadable-object (token stream :type t :identity t)
-      (format stream "type: ~a text: ~a value: ~a location: ~a" type text value location))))
+      (format stream "type: ~a lexeme: ~a value: ~a location: ~a" type lexeme value location))))
+
+(-> class= (token token-class) boolean)
+(defun class= (token expected-class)
+  "Returns true if the token's class is equal to the given `expected-class.'"
+  (eql (token-class token) expected-class))

--- a/src/compiler/frontend/scanner/token.lisp
+++ b/src/compiler/frontend/scanner/token.lisp
@@ -1,0 +1,19 @@
+(in-package :cl-braces.compiler.frontend.scanner)
+
+(deftype tpe-token-type ()
+  "The type of a token. This is a simple enumeration of all the different kinds of tokens that can be encountered in the"
+  '(member
+    :tok-illegal
+    :tok-eof))
+
+(defclass token ()
+  ((type :reader token-type :initarg :type :initform (error "no type given") :type tpe-token-type)
+   (text :reader token-text :initarg :text :initform (error "no text given") :type string)
+   (value :reader token-value :initarg :value :initform nil :type (or null t))
+   (location :reader token-location :initarg :location :initform (error "no location given") :type source-location))
+  (:documentation "A token is a single unit of input. It is the smallest unit of input that the parser can work with."))
+
+(defmethod print-object ((token token) stream)
+  (with-slots (type text value location) token
+    (print-unreadable-object (token stream :type t :identity t)
+      (format stream "type: ~a text: ~a value: ~a location: ~a" type text value location))))

--- a/src/development.lisp
+++ b/src/development.lisp
@@ -1,0 +1,27 @@
+(in-package :cl-user)
+
+(defpackage :cl-braces.development
+  (:nicknames :dev)
+  (:use :cl)
+  (:export
+   :todo!
+   :unreachable!
+   :pry))
+
+(in-package :cl-braces.development)
+
+(defmacro todo! (message)
+  (let ((full-message (gensym)))
+    `(let ((,full-message (concatenate 'string "TODO: " ,message)))
+       (error ,full-message))))
+
+(defmacro unreachable! (message)
+  (let ((full-message (gensym)))
+    `(let ((,full-message (concatenate 'string "UNREACHABLE: " ,message)))
+       (error ,full-message))))
+
+(defmacro pry (&body form)
+  (let ((result (gensym)))
+    `(let ((,result (progn ,@form)))
+       (format *debug-io* "~&👀  ~a => ~a" ',form ,result)
+       ,result)))

--- a/tests/compiler/frontend/parser_suite.lisp
+++ b/tests/compiler/frontend/parser_suite.lisp
@@ -1,0 +1,9 @@
+(in-package :cl-braces.compiler.tests)
+
+(defsuite parser-suite (frontend-suite))
+
+(deftest parse-integer-literal (parser-suite)
+  "Parse an integer literal"
+  (let ((node (parser:parse "3")))
+    (assert-equalp (type-of node) 'ast:literal)
+    (assert-equalp (ast:literal-value node) 3)))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -22,3 +22,22 @@
   (assert-scans-as "1234"  token:@INTEGER :with-value 1234)
   (assert-scans-as "+1234" token:@INTEGER :with-value 1234)
   (assert-scans-as "-4231" token:@INTEGER :with-value -4231))
+
+(deftest location-tracking (scanner-suite)
+  "Scan multiple tokens and track the location correctly for each"
+  (let* ((s (scanner:open-scanner (format nil "   3~%4   5")))
+         (t1 (scanner:next-token s))
+         (t2 (scanner:next-token s))
+         (t3 (scanner:next-token s)))
+
+    (assert-equalp 1 (token:location-line (token:location t1)))
+    (assert-equalp 4 (token:location-column (token:location t1)))
+    (assert-equalp 3 (token:location-offset (token:location t1)))
+
+    (assert-equalp 2 (token:location-line (token:location t2)))
+    (assert-equalp 1 (token:location-column (token:location t2)))
+    (assert-equalp 5 (token:location-offset (token:location t2)))
+
+    (assert-equalp 2 (token:location-line (token:location t3)))
+    (assert-equalp 5 (token:location-column (token:location t3)))
+    (assert-equalp 9 (token:location-offset (token:location t3)))))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -2,10 +2,12 @@
 
 (defsuite scanner-suite (frontend-suite))
 
-(defmacro assert-scans-as (input token-type)
+(defmacro assert-scans-as (input token-type &key (with-value nil))
   (let ((token-var (gensym)))
     `(let ((,token-var (scanner:call-with-scanner ,input #'scanner:next-token)))
-       (assert-equality #'eql ,token-type (scanner:token-type ,token-var)))))
+       (assert-equality #'eql ,token-type (scanner:token-type ,token-var))
+       ,@(when with-value
+           `((assert-equality #'eql ,with-value (scanner:token-value ,token-var)))))))
 
 (deftest scan-eof (scanner-suite)
   "Make sure the scanner recognizes the end of the input"
@@ -14,3 +16,9 @@
 (deftest scan-illegal (scanner-suite)
   "All unknown tokens scan as illegal"
   (assert-scans-as "#unknown#" :tok-illegal))
+
+(deftest scan-integer (scanner-suite)
+  "Scan a numeric integer literal"
+  (assert-scans-as "1234" :tok-integer :with-value 1234)
+  (assert-scans-as "+1234" :tok-integer :with-value 1234)
+  (assert-scans-as "-4231" :tok-integer :with-value -4231))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -2,23 +2,23 @@
 
 (defsuite scanner-suite (frontend-suite))
 
-(defmacro assert-scans-as (input token-type &key (with-value nil))
+(defmacro assert-scans-as (input token-class &key (with-value nil))
   (let ((token-var (gensym)))
     `(let ((,token-var (scanner:call-with-scanner ,input #'scanner:next-token)))
-       (assert-equality #'eql ,token-type (scanner:token-type ,token-var))
+       (assert-equality #'eql ,token-class (token:token-class ,token-var))
        ,@(when with-value
-           `((assert-equality #'eql ,with-value (scanner:token-value ,token-var)))))))
+           `((assert-equality #'eql ,with-value (token:token-value ,token-var)))))))
 
 (deftest scan-eof (scanner-suite)
-  "Make sure the scanner recognizes the end of the input"
-  (assert-scans-as "" :tok-eof))
+  "Scan the end of file"
+  (assert-scans-as "" :@EOF))
 
 (deftest scan-illegal (scanner-suite)
-  "All unknown tokens scan as illegal"
-  (assert-scans-as "#unknown#" :tok-illegal))
+  "Scan unknown characters as illegal tokens"
+  (assert-scans-as "#unknown#" :@ILLEGAL))
 
 (deftest scan-integer (scanner-suite)
-  "Scan a numeric integer literal"
-  (assert-scans-as "1234" :tok-integer :with-value 1234)
-  (assert-scans-as "+1234" :tok-integer :with-value 1234)
-  (assert-scans-as "-4231" :tok-integer :with-value -4231))
+  "Scan an integer literal"
+  (assert-scans-as "1234"  :@INTEGER :with-value 1234)
+  (assert-scans-as "+1234" :@INTEGER :with-value 1234)
+  (assert-scans-as "-4231" :@INTEGER :with-value -4231))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -1,0 +1,16 @@
+(in-package :cl-braces.compiler.tests)
+
+(defsuite scanner-suite (frontend-suite))
+
+(defmacro assert-scans-as (input token-type)
+  (let ((token-var (gensym)))
+    `(let ((,token-var (scanner:call-with-scanner ,input #'scanner:next-token)))
+       (assert-equality #'eql ,token-type (scanner:token-type ,token-var)))))
+
+(deftest scan-eof (scanner-suite)
+  "Make sure the scanner recognizes the end of the input"
+  (assert-scans-as "" :tok-eof))
+
+(deftest scan-illegal (scanner-suite)
+  "All unknown tokens scan as illegal"
+  (assert-scans-as "#unknown#" :tok-illegal))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -5,9 +5,9 @@
 (defmacro assert-scans-as (input token-class &key (with-value nil))
   (let ((token-var (gensym)))
     `(let ((,token-var (scanner:call-with-scanner ,input #'scanner:next-token)))
-       (assert-equality #'eql ,token-class (token:token-class ,token-var))
+       (assert-equalp ,token-class (token:token-class ,token-var))
        ,@(when with-value
-           `((assert-equality #'eql ,with-value (token:token-value ,token-var)))))))
+           `((assert-equalp ,with-value (token:token-value ,token-var)))))))
 
 (deftest scan-eof (scanner-suite)
   "Scan the end of file"

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -11,14 +11,14 @@
 
 (deftest scan-eof (scanner-suite)
   "Scan the end of file"
-  (assert-scans-as "" :@EOF))
+  (assert-scans-as "" token:@EOF))
 
 (deftest scan-illegal (scanner-suite)
   "Scan unknown characters as illegal tokens"
-  (assert-scans-as "#unknown#" :@ILLEGAL))
+  (assert-scans-as "#unknown#" token:@ILLEGAL))
 
 (deftest scan-integer (scanner-suite)
   "Scan an integer literal"
-  (assert-scans-as "1234"  :@INTEGER :with-value 1234)
-  (assert-scans-as "+1234" :@INTEGER :with-value 1234)
-  (assert-scans-as "-4231" :@INTEGER :with-value -4231))
+  (assert-scans-as "1234"  token:@INTEGER :with-value 1234)
+  (assert-scans-as "+1234" token:@INTEGER :with-value 1234)
+  (assert-scans-as "-4231" token:@INTEGER :with-value -4231))

--- a/tests/compiler/frontend/scanner_suite.lisp
+++ b/tests/compiler/frontend/scanner_suite.lisp
@@ -5,9 +5,9 @@
 (defmacro assert-scans-as (input token-class &key (with-value nil))
   (let ((token-var (gensym)))
     `(let ((,token-var (scanner:call-with-scanner ,input #'scanner:next-token)))
-       (assert-equalp ,token-class (token:token-class ,token-var))
+       (assert-equalp ,token-class (token:class ,token-var))
        ,@(when with-value
-           `((assert-equalp ,with-value (token:token-value ,token-var)))))))
+           `((assert-equalp ,with-value (token:value ,token-var)))))))
 
 (deftest scan-eof (scanner-suite)
   "Scan the end of file"

--- a/tests/compiler/suites.lisp
+++ b/tests/compiler/suites.lisp
@@ -1,7 +1,5 @@
 (in-package :cl-braces.compiler.tests)
 
-(defparameter *exit-on-failure* nil)
-
 (defsuite compiler-suite ())
 (defsuite frontend-suite (compiler-suite))
 
@@ -9,5 +7,5 @@
   (let ((result (run-suite 'compiler-suite :report-progress nil)))
     (when (or (plusp (clunit::errors result))
               (plusp (clunit::failed result)))
-      (when *exit-on-failure*
+      (when (uiop:getenvp "CI")
         (uiop:quit 1)))))

--- a/tests/compiler/suites.lisp
+++ b/tests/compiler/suites.lisp
@@ -7,5 +7,5 @@
   (let ((result (run-suite 'compiler-suite :report-progress nil)))
     (when (or (plusp (clunit::errors result))
               (plusp (clunit::failed result)))
-      (when (uiop:getenvp "CI")
+      (when (uiop:getenvp "CI_ENV")
         (uiop:quit 1)))))

--- a/tests/compiler/suites.lisp
+++ b/tests/compiler/suites.lisp
@@ -1,12 +1,13 @@
 (in-package :cl-braces.compiler.tests)
 
+(defparameter *exit-on-failure* nil)
+
 (defsuite compiler-suite ())
+(defsuite frontend-suite (compiler-suite))
 
-(deftest trivially-true (compiler-suite)
-  (assert-true (= 1 1)))
-
-(defun run-all-with-exit ()
+(defun run-all ()
   (let ((result (run-suite 'compiler-suite :report-progress nil)))
     (when (or (plusp (clunit::errors result))
               (plusp (clunit::failed result)))
-      (uiop:quit 1))))
+      (when *exit-on-failure*
+        (uiop:quit 1)))))


### PR DESCRIPTION
Create the amount of code to parse an integer literal.

This naturally includes some bootstrap code.
Yet it is one of the simplest things we can do. 

Further changes will be smaller and more focused. 