### PR TITLE
compiler/frontend: parse binary expressions

### DIFF
--- a/src/compiler/frontend/parser/ast.lisp
+++ b/src/compiler/frontend/parser/ast.lisp
@@ -30,6 +30,14 @@
 (defun literal-value (expression)
   (token:value (literal-token expression)))
 
+(defclass grouping-expression (expression)
+  ((expression
+    :reader grouping-expression-expression
+    :initarg :expression
+    :initform (error "must provide expression")
+    :type expression))
+  (:documentation "An expression that is surrounded by parentheses."))
+
 (defclass unary-expression (expression)
   ((operator
     :reader unary-expression-operator
@@ -49,11 +57,11 @@
     :initarg :lhs
     :initform (error "must provide lhs")
     :type expression)
-   (operand
-    :reader unary-expression-operand
-    :initarg :operand
-    :initform (error "must provide operand")
-    :type expression)
+   (operator
+    :reader binary-expression-operator
+    :initarg :operator
+    :initform (error "must provide operator")
+    :type token:token)
    (rhs
     :reader binary-expression-rhs
     :initarg :rhs

--- a/src/compiler/frontend/parser/ast.lisp
+++ b/src/compiler/frontend/parser/ast.lisp
@@ -42,3 +42,21 @@
     :initform (error "must provide operand")
     :type expression))
   (:documentation "An expression for binary relations"))
+
+(defclass binary-expression (expression)
+  ((lhs
+    :reader binary-expression-lhs
+    :initarg :lhs
+    :initform (error "must provide lhs")
+    :type expression)
+   (operand
+    :reader unary-expression-operand
+    :initarg :operand
+    :initform (error "must provide operand")
+    :type expression)
+   (rhs
+    :reader binary-expression-rhs
+    :initarg :rhs
+    :initform (error "must provide rhs")
+    :type expression))
+  (:documentation "An expression for binary relations"))

--- a/src/compiler/frontend/parser/packages.lisp
+++ b/src/compiler/frontend/parser/packages.lisp
@@ -15,6 +15,11 @@
    :unary-expression-operator
    :unary-expression-operand
 
+   :binary-expression
+   :binary-expression-lhs
+   :binary-expression-operator
+   :binary-expression-rhs
+
    :walk
    :enter
    :leave))

--- a/src/compiler/frontend/parser/packages.lisp
+++ b/src/compiler/frontend/parser/packages.lisp
@@ -11,6 +11,9 @@
    :literal
    :literal-value
 
+   :grouping-expression
+   :grouping-expression-expression
+
    :unary-expression
    :unary-expression-operator
    :unary-expression-operand

--- a/src/compiler/frontend/parser/parser.lisp
+++ b/src/compiler/frontend/parser/parser.lisp
@@ -5,6 +5,15 @@
 ;;; When a parse fails, the parse will insert a sentinel node into the AST and continue parsing.
 ;;; The recovery is relatively simple and attempts to synchronize to the next statement boundary.
 
+(defmacro define-enum (name &rest variants)
+  (let ((iota 0))
+    `(progn
+       ,@(mapcar (lambda (variant)
+                   (prog1 `(defconstant ,(intern (format nil "+~A-~A+" name variant)) ,iota)
+                     (incf iota)))
+                 variants)
+       (deftype ,(intern (format nil "~A" name)) () '(integer 0 ,iota)))))
+
 (defparameter *fail-fast* nil "If true the parser will signal a continuable parse-error condition when an error is encountered. When continued the parser will attempt to synchronize to the next statement boundary.")
 
 (define-condition parse-errors (error)
@@ -57,24 +66,94 @@
     :documentation "A flag indicating if the parser is in panic mode"))
   (:documentation "The state of the parser which is threaded through all parsing methods"))
 
-(defun parse (input-desginator)
-  (scanner:call-with-scanner
-   input-desginator
-   (lambda (scanner)
-     (let ((state (make-instance 'state :scanner scanner)))
-       (%parse state)))))
+(defun parse-with (input parser &rest args)
+  (call-with-parse-state
+   input
+   (lambda (state)
+     (handler-bind ((error-detail (lambda (c) (if *fail-fast* (invoke-debugger c) (invoke-restart 'continue)))))
+       (advance! state)
+       (apply #'funcall parser state args)))))
 
-(-> %parse (state) (or null ast:node))
+(defun parse (input-desginator)
+  (call-with-parse-state input-desginator #'%parse))
+
+(-> %parse (state) (values (or null ast:node) boolean state))
 (defun %parse (state)
   (handler-bind ((error-detail (lambda (c) (if *fail-fast* (invoke-debugger c) (invoke-restart 'continue)))))
-    (advance! state)
-    (prog1 (parse-expression state)
-      (consume! state token:@EOF "Expected end of file"))))
+    (with-slots (had-errors-p) state
+      (advance! state) ; prime the state
+      (let ((ast (parse-expression state)))
+        (consume! state token:@EOF "Expected end of file")
+        (values ast had-errors-p state)))))
 
-(defun parse-expression (state)
+(defun call-with-parse-state (input fn)
+  (scanner:call-with-scanner
+   input
+   (lambda (scanner)
+     (let ((state (make-instance 'state :scanner scanner)))
+       (funcall fn state)))))
+
+(define-enum precedence
+  none
+  assignment ; =
+  term       ; + -
+  factor     ; * /
+  unary      ; + - !
+  primary)
+
+(define-enum associativity
+  none
+  left
+  right)
+
+(serapeum:defconst +operator-rules+
+  (serapeum:dict
+   token:@MINUS  (cons +precedence-term+ +associativity-left+)
+   token:@PLUS   (cons +precedence-term+ +associativity-left+)
+   token:@SLASH  (cons +precedence-factor+ +associativity-left+)
+   token:@STAR   (cons +precedence-factor+ +associativity-left+)
+   token:@LPAREN (cons +precedence-none+ +associativity-none+)))
+
+(defun operator-rule-for (token-class)
+  (gethash token-class +operator-rules+ (cons +precedence-none+ +associativity-none+)))
+
+(defun parse-expression (state &optional (current-min-precedence +precedence-assignment+))
+  "Parse and expression respecting precedence and associativity rules of the operators.
+It is implemented using the [precedence climbing algorithm](https://en.wikipedia.org/wiki/Operator-precedence_parser).
+The main idea behind the algorithm is that an expression contains of groups of subexpressions that are connected by the
+operator with the lowest precedence.
+
+Example:
+2 + 3 ^ 2 * 3 + 4
+
+|---------------|   : prec 1
+    |-------|       : prec 2
+    |---|           : prec 3
+
+The algorithm fits well into the overall recursive descent approach, which we take for the rest of the parser.
+During recursive calls to parse subexpression we pass the current precedence level and the associativity of the operator
+subexpression or to return the result to the caller.
+
+The primary expressio in this algorithm are the literals and the grouping expressions.
+"
+  (with-slots (cur-token) state
+    (loop with left = (parse-primary-expression state)
+          with right = nil
+          do
+             (destructuring-bind (prec . assoc) (operator-rule-for (token:class cur-token))
+               (when (< prec current-min-precedence)
+                 (return left))
+               (let ((operator cur-token)
+                     (next-min-precedence (if (= assoc +associativity-left+) (1+ prec) prec)))
+                 (advance! state)
+                 (setf right (parse-expression state next-min-precedence))
+                 (setf left (accept state 'ast:binary-expression :lhs left :operator operator :rhs right)))))))
+
+(defun parse-primary-expression (state)
   (or
+   (parse-literal state)
    (parse-unary-expression state)
-   (parse-literal state)))
+   (parse-grouping-expression state)))
 
 (defun parse-literal (state)
   (or (parse-number-literal state)))
@@ -82,8 +161,17 @@
 (-> parse-number-literal (state) (or null ast:literal))
 (defun parse-number-literal (state)
   (let ((tok (consume! state token:@INTEGER "Expected number literal")))
-    (unless (token:class= tok token:@ILLEGAL)
-      (accept state 'ast:literal :token tok))))
+    (when tok
+      (unless (token:class= tok token:@ILLEGAL)
+        (accept state 'ast:literal :token tok)))))
+
+(defun parse-grouping-expression (state)
+  (let ((tok (consume! state token:@LPAREN "Expected '('")))
+    (when tok
+      (unless (token:class= tok token:@ILLEGAL)
+        (let ((expr (parse-expression state +precedence-term+)))
+          (consume! state token:@RPAREN "Expected ')' after expression")
+          (accept state 'ast:grouping-expression :expression expr))))))
 
 (-> parse-unary-expression (state) (or null ast:expression))
 (defun parse-unary-expression (state)
@@ -93,7 +181,7 @@
       ((or (token:class= cur-token token:@PLUS) (token:class= cur-token token:@MINUS))
        (let ((op cur-token))
          (advance! state)
-         (accept state 'ast:unary-expression :operator op :operand (parse-expression state)))))))
+         (accept state 'ast:unary-expression :operator op :operand (parse-primary-expression state)))))))
 
 (-> eofp (state) boolean)
 (defun eofp (state)
@@ -120,14 +208,15 @@
         (signal-parse-error state "Illegal token"))
       (values cur-token next-token))))
 
-(-> consume! (state token:token-class string &rest list) token:token)
+(-> consume! (state token:token-class string &rest list) (or null token:token))
 (defun consume! (state expected-token-class format-string &rest args)
   "Consumes input expecting it to be of the given token type"
   (with-slots (cur-token) state
     (assert cur-token) ; we can only get here when consume! has been called withoud advance!
 
     (unless (token:class= cur-token expected-token-class)
-      (signal-parse-error state format-string args))
+      (signal-parse-error state format-string args)
+      (return-from consume! nil))
     (prog1 cur-token
       (advance! state))))
 
@@ -153,16 +242,14 @@
   (with-slots (next-token) state
     (signal-parse-error-at state next-token format-string args)))
 
-(-> signal-parse-error-at (state token:token string &rest t) null)
+(-> signal-parse-error-at (state token:token string &rest t) (or null error-detail))
 (defun signal-parse-error-at (state token format-string &rest args)
   (with-slots (panic-mode-p had-errors-p errors scanner) state
-
-    (when panic-mode-p (return-from signal-parse-error-at))
-
-    (setf panic-mode-p t)
-    (setf had-error-p t)
-
-    (let* ((loc (token:location token))
-           (parse-error (make-condition 'error-detail :location loc :message (apply #'format nil format-string args))))
-      (cerror "Continue parsing collecting this error" parse-error)
-      (push parse-error errors))))
+    (unless panic-mode-p
+      (setf panic-mode-p t)
+      (setf had-errors-p t)
+      (let* ((loc (token:location token))
+             (parse-error (make-condition 'error-detail :location loc :message (apply #'format nil format-string args))))
+        (cerror "Continue parsing collecting this error" parse-error)
+        (prog1 parse-error
+          (push parse-error errors))))))

--- a/tests/compiler/frontend/parser_suite.lisp
+++ b/tests/compiler/frontend/parser_suite.lisp
@@ -20,3 +20,11 @@
     (assert-eql 'ast:unary-expression (type-of node))
     (assert-eql token:@PLUS (token:class (ast:unary-expression-operator node)))
     (assert-eql 'ast:literal (type-of (ast:unary-expression-operand node)))))
+
+(define-test parse-binary-plus ()
+  "Parse binary plus with two operands"
+  (let ((node (parser:parse "3 + 4")))
+    (assert-eql 'ast:binary-expression (type-of node))
+    (assert-eql 'ast:literal (type-of (ast:binary-expression-lhs node)))
+    (assert-eql token:@PLUS (token:class (ast:binary-expression-operator node)))
+    (assert-eql 'ast:literal (type-of (ast:binary-expression-rhs node)))))

--- a/tests/compiler/frontend/parser_suite.lisp
+++ b/tests/compiler/frontend/parser_suite.lisp
@@ -1,6 +1,5 @@
 (in-package :tests.frontend.parser)
 
-
 (define-test parse-integer-literal ()
   "Parse an integer literal"
   (let ((node (parser:parse "3")))
@@ -21,6 +20,12 @@
     (assert-eql token:@PLUS (token:class (ast:unary-expression-operator node)))
     (assert-eql 'ast:literal (type-of (ast:unary-expression-operand node)))))
 
+(define-test parse-grouping ()
+  "Parse grouping expression with two operands"
+  (let ((node (parser:parse "(3 - 4)")))
+    (assert-eql 'ast:grouping-expression (type-of node))
+    (assert-eql 'ast:binary-expression (type-of (ast:grouping-expression-expression node)))))
+
 (define-test parse-binary-plus ()
   "Parse binary plus with two operands"
   (let ((node (parser:parse "3 + 4")))
@@ -28,3 +33,44 @@
     (assert-eql 'ast:literal (type-of (ast:binary-expression-lhs node)))
     (assert-eql token:@PLUS (token:class (ast:binary-expression-operator node)))
     (assert-eql 'ast:literal (type-of (ast:binary-expression-rhs node)))))
+
+(define-test parse-binary-minus ()
+  "Parse binary minus with two operands"
+  (let ((node (parser:parse "3 - 4")))
+    (assert-eql 'ast:binary-expression (type-of node))
+    (assert-eql 'ast:literal (type-of (ast:binary-expression-lhs node)))
+    (assert-eql token:@MINUS (token:class (ast:binary-expression-operator node)))
+    (assert-eql 'ast:literal (type-of (ast:binary-expression-rhs node)))))
+
+(define-test parse-binary-with-mixed-precedence-operators ()
+  "Parse binary expressions with operators with mixed precedence"
+  (let ((node (parser:parse "3 - 4 * 5")))
+    (assert-eql 'ast:binary-expression (type-of node))
+    (assert-eql token:@MINUS (token:class (ast:binary-expression-operator node)))
+
+    (let ((lhs (ast:binary-expression-lhs node))
+          (rhs (ast:binary-expression-rhs node)))
+      (assert-eql 'ast:literal (type-of lhs))
+      (assert-eql 'ast:binary-expression (type-of rhs))
+
+      (let ((rhs-lhs (ast:binary-expression-lhs rhs))
+            (rhs-rhs (ast:binary-expression-rhs rhs)))
+        (assert-eql 'ast:literal (type-of rhs-lhs))
+        (assert-eql token:@STAR (token:class (ast:binary-expression-operator rhs)))
+        (assert-eql 'ast:literal (type-of rhs-rhs))))))
+
+(define-test parse-binary-with-explicit-grouping ()
+  "Parse a binary expression that has explicit grouping"
+  (let ((node (parser:parse "(3 - 4) * 5")))
+    (assert-eql 'ast:binary-expression (type-of node))
+    (assert-eql token:@STAR (token:class (ast:binary-expression-operator node)))
+    (let ((lhs (ast:binary-expression-lhs node))
+          (rhs (ast:binary-expression-rhs node)))
+      (assert-eql 'ast:grouping-expression (type-of lhs))
+      (assert-eql 'ast:literal (type-of rhs))
+
+      (let ((inner (ast:grouping-expression-expression lhs)))
+        (assert-eql 'ast:binary-expression (type-of inner))
+        (assert-eql token:@MINUS (token:class (ast:binary-expression-operator inner)))
+        (assert-eql 'ast:literal (type-of (ast:binary-expression-lhs inner)))
+        (assert-eql 'ast:literal (type-of (ast:binary-expression-rhs inner)))))))


### PR DESCRIPTION
This updates the parser so that it recognises binary expressions. 
It adheres to proper precedence and associativity rules by applying the precedence
climbing algorithm. 